### PR TITLE
DR2DR-3913

### DIFF
--- a/ng-tags-input.css
+++ b/ng-tags-input.css
@@ -165,6 +165,7 @@ tags-input .autocomplete .suggestion-item {
   font: 16px "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #000;
   background-color: #fff;
+  height: 28px;
 }
 tags-input .autocomplete .suggestion-item.selected {
   color: #262626;

--- a/ng-tags-input.js
+++ b/ng-tags-input.js
@@ -743,7 +743,6 @@ tagsInput.directive('autoComplete', ["$document", "$timeout", "$sce", "$q", "tag
                         offsetTop += elem.offsetTop;
                     }
                 } while( elem = elem.offsetParent );
-                console.log(offsetTop);
                 return offsetTop;
             }
 
@@ -752,8 +751,11 @@ tagsInput.directive('autoComplete', ["$document", "$timeout", "$sce", "$q", "tag
                 top: null
             };
 
-            scope.shouldDisplayUpwards = function(element, items) {
-                return window.innerHeight - getOffsetTop(element[0]) < 300;
+            scope.shouldDisplayUpwards = function(element, numOfItems) {
+                const itemVerticalOffset = (numOfItems * 28);
+                const totalItemVerticalOffset = getOffsetTop(element[0]) +  itemVerticalOffset;
+                const safeMargin = 20;
+                return ( window.innerHeight - totalItemVerticalOffset ) < safeMargin;
             };
 
             scope.templateScope = tagsInput.getTemplateScope();
@@ -822,24 +824,13 @@ tagsInput.directive('autoComplete', ["$document", "$timeout", "$sce", "$q", "tag
                         var promise = suggestionList.load(value, tagsInput.getTags());
                         promise.then(
                             function(items){
-                                if (items && scope.shouldDisplayUpwards(element)) {
-                                    console.log(items.length);
+                                if (items && scope.shouldDisplayUpwards(element, items.length)) {
                                     scope.displayDirection.top = (-1 * ( ( items.length * 28 ) + 15 ) ).toString() + 'px';
-                                    console.log(scope.displayDirection);
                                 } else {
                                     scope.displayDirection.top = null;
                                 }
                             }
                         );
-                        /*
-                        if (scope.shouldDisplayUpwards(element)) {
-                            console.log(suggestionList.items.length);
-                            scope.displayDirection.top = (-1 * ( ( suggestionList.items.length * 28 ) + 15 ) ).toString() + 'px';
-                            console.log(scope.displayDirection);
-                        } else {
-                            scope.displayDirection.top = null;
-                        }*/
-
                     }
                     else {
                         suggestionList.reset();

--- a/ng-tags-input.js
+++ b/ng-tags-input.js
@@ -850,6 +850,8 @@ tagsInput.directive('autoComplete', ["$document", "$timeout", "$sce", "$q", "tag
                             // DR2DR-3913
                             function(items){
                                 if (items && scope.shouldDisplayUpwards(element, items.length)) {
+                                    // best selections appear at the bottom of the upwards facing list
+                                    items.reverse();
                                     scope.displayDirection.top = (-1 * ( ( items.length * 28 ) + 15 ) ).toString() + 'px';
                                 } else {
                                     scope.displayDirection.top = null;


### PR DESCRIPTION
* added attributes to determine direction of suggestion list
  * one can specify the direction `up` or `down` to force the suggestion list to render upwards or downwards
  * one can specify a strategy to determine if the list should render upwards or downwards. The `static strategy` is such that it takes the maximum suggestion list height (maxItems * itemHeight) into account when determining the render direction. The `dynamic strategy` takes into account the number of items in the current list. The `static strategy` is probably better because the `dynamic strategy` can cause the list to jump upwards or downwards depending on the number of results.