### PR TITLE
DR2DR-3913

### DIFF
--- a/ng-tags-input.js
+++ b/ng-tags-input.js
@@ -852,7 +852,8 @@ tagsInput.directive('autoComplete', ["$document", "$timeout", "$sce", "$q", "tag
                                 if (items && scope.shouldDisplayUpwards(element, items.length)) {
                                     // best selections appear at the bottom of the upwards facing list
                                     items.reverse();
-                                    scope.displayDirection.top = (-1 * ( ( items.length * 28 ) + 15 ) ).toString() + 'px';
+                                    var length = items.length > options.maxResultsToShow ? options.maxResultsToShow : items.length;
+                                    scope.displayDirection.top = (-1 * ( ( length * 28 ) + 15 ) ).toString() + 'px';
                                 } else {
                                     scope.displayDirection.top = null;
                                 }


### PR DESCRIPTION
* when suggestion list is displayed upwards, take into account the case where the number of returned items is greater than the max number of items to show. Ignoring this case will lead to the suggestion list being rendered too far away from the input.